### PR TITLE
Use plugins/ subdirectory for plugins fetched with `plug` and `plug-old`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+plugins/


### PR DESCRIPTION
Usecase: Having Kakoune config in a dotfiles repo and not wanting to gitignore all of `autoload/`.
Directory can be changed by modifying `plug_plugin_dir` option like this:

```kak
set-option global plug_plugin_dir "%val{config}/autoload"
```
