### PR TITLE
Also redirect stderr to plug.fifo

### DIFF
--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -52,7 +52,7 @@ provide-module plug %{
   define-command -hidden plug-fifo -params 1.. -docstring 'plug-fifo <command>' %{
     nop %sh(mkfifo plug.fifo)
     edit -fifo plug.fifo '*plug*'
-    nop %sh(("$@" > plug.fifo; rm plug.fifo) < /dev/null > /dev/null 2>&1 &)
+    nop %sh(("$@" > plug.fifo 2>&1; rm plug.fifo) < /dev/null > /dev/null 2>&1 &)
   }
 
   define-command plug-install -docstring 'plug-install' %{


### PR DESCRIPTION
Because `git clone` outputs to stderr