### PR TITLE
Add highlighting for plug commands in .kak files

### DIFF
--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -23,6 +23,10 @@ provide-module plug %{
   add-highlighter shared/plug/code default-region group
   add-highlighter shared/plug/code/message regex '(?S)^(.+?): (.+?)$' 0:keyword 1:value
 
+  hook global ModuleLoaded kak %{
+    add-highlighter shared/kakrc/code/plug_commands regex (?:\s|\A)\K(plug|plug-core|plug-autoload|plug-old)(?:(?=\s)|\z) 0:keyword
+  }
+
   define-command plug -params 2..3 -docstring 'plug <module> <repository> [config]' %{
     set-option -add global plug_modules %arg{1}
     set-option -add global plug_module_to_repository_map %arg{1} %arg{2}


### PR DESCRIPTION
First I looked at [plug.kak 1](https://github.com/robertmeta/plug.kak/blob/cf02b00f3764cbd03ce9ab6eec2f4eed035c0737/rc/plug.kak#L73) to see how it was implemented there.
Just copying that into plug.kak 2 didn't work because here we have commands with `-` and those are excluded by `\b`.

So then I took a look at Kakoune's `rc/filetype/kakrc.kak` and used that instead. I'm not _exactly_ sure what each of the regex sequences mean but I got a good grasp of it and I'm confident this is fine.

Oh and feel free to reject it if you think the plug keywords shouldn't be highlighted at all. Having this as extra config in kakrc works for me too.